### PR TITLE
ゲストアカウントの簡易保護

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   protected
   # ストロングパラメータを定義
     def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :image])
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :image, :profile])
       devise_parameter_sanitizer.permit(:sign_in, keys: [:username])
       devise_parameter_sanitizer.permit(:account_update, keys: [:username, :profile, :password, :image, :remove_image])
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   protected
   # ストロングパラメータを定義
     def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :image, :profile])
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :image, :profile, :guest_flg])
       devise_parameter_sanitizer.permit(:sign_in, keys: [:username])
       devise_parameter_sanitizer.permit(:account_update, keys: [:username, :profile, :password, :image, :remove_image])
     end

--- a/app/views/articles/_article_card.html.erb
+++ b/app/views/articles/_article_card.html.erb
@@ -8,7 +8,7 @@
       <div class="d-flex flex-column align-self-center">
         <div class="mr-1 font-weight-bold text-left" id="author">
           <%= article.author.username %>
-          <%= render 'users/user_card_admin_badge', user: article.author %>
+          <%= render 'users/user_card_attribute_badge', user: article.author %>
         </div>
         <div class="text-truncate" id="date"><%= article.created_at.strftime("%m月%d日 %H:%M") %></div>
       </div>

--- a/app/views/articles/_articles_cards_card.html.erb
+++ b/app/views/articles/_articles_cards_card.html.erb
@@ -8,7 +8,7 @@
         <div class="d-flex flex-column align-self-center" id="date">
           <div class="mr-1 font-weight-bold text-left" id="author">
             <%= article.author.username %>
-            <%= render 'users/user_card_admin_badge', user: article.author %>
+            <%= render 'users/user_card_attribute_badge', user: article.author %>
           </div>
           <div class="text-truncate" id="date"><%= article.created_at.strftime("%m月%d日 %H:%M") %></div>
         </div>

--- a/app/views/articles/_articles_cards_card_modal_article.html.erb
+++ b/app/views/articles/_articles_cards_card_modal_article.html.erb
@@ -10,7 +10,7 @@
             <div class="d-flex flex-column align-self-center" id="date">
               <div class="mr-1 font-weight-bold text-left" id="author">
                 <%= article.author.username %>
-                <%= render 'users/user_card_admin_badge', user: article.author %>
+                <%= render 'users/user_card_attribute_badge', user: article.author %>
               </div>
               <div class="text-truncate" id="date"><%= article.created_at.strftime("%m月%d日 %H:%M") %></div>
             </div>

--- a/app/views/comments/_comment_card.html.erb
+++ b/app/views/comments/_comment_card.html.erb
@@ -8,7 +8,7 @@
         <div class="flex-column">
           <div class="font-weight-bold" id="name">
             <%= link_to comment.commenter.username, comment.commenter, id: "user-page" %>
-            <%= render 'users/user_card_admin_badge', user: comment.commenter %>
+            <%= render 'users/user_card_attribute_badge', user: comment.commenter %>
           </div>
           <div class="d-flex">
             <div id="date"><%= comment.created_at.strftime("%Y/%m/%d %H:%M") %></div>

--- a/app/views/comments/_comment_form_post.html.erb
+++ b/app/views/comments/_comment_form_post.html.erb
@@ -10,7 +10,7 @@
           <div class="flex-column">
             <div class="font-weight-bold" id="name">
               <%= current_user.username %>
-              <%= render 'users/user_card_admin_badge', user: current_user %>
+              <%= render 'users/user_card_attribute_badge', user: current_user %>
             </div>
           </div>
         </div>

--- a/app/views/comments/_user_tablist_comment_card_article.html.erb
+++ b/app/views/comments/_user_tablist_comment_card_article.html.erb
@@ -15,7 +15,7 @@
         <div class="d-flex flex-column align-self-center" id="date">
           <div class="mr-1 font-weight-bold text-left" id="author">
             <%= article.author.username %>
-            <%= render 'users/user_card_admin_badge', user: article.author %>
+            <%= render 'users/user_card_attribute_badge', user: article.author %>
           </div>
           <div class="text-truncate" id="date"><%= article.created_at.strftime("%m月%d日 %H:%M") %></div>
         </div>

--- a/app/views/comments/_user_tablist_comment_card_comment.html.erb
+++ b/app/views/comments/_user_tablist_comment_card_comment.html.erb
@@ -7,7 +7,7 @@
       <div class="flex-column">
         <div class="font-weight-bold" id="name">
           <%= comment.commenter.username %>
-          <%= render 'users/user_card_admin_badge', user: comment.commenter %>
+          <%= render 'users/user_card_attribute_badge', user: comment.commenter %>
         </div>
         <div class="d-flex">
           <div id="date"><%= comment.created_at.strftime("%Y/%m/%d %H:%M") %></div>

--- a/app/views/devise/_guest-form.html.erb
+++ b/app/views/devise/_guest-form.html.erb
@@ -14,6 +14,7 @@
         <%= f.hidden_field :username, value: "ゲスト甲" %>
         <%= f.hidden_field :email, value: "guest1@mail.com" %>
         <%= f.hidden_field :profile, value: "このアカウントはポートフォリオの内容を確認するためのものです。" %>
+        <%= f.hidden_field :guest_flg, value: "true" %>
         <%= f.hidden_field :password, value: "guestguest1" %>
       </div>
       <%= f.submit 'ゲスト甲として登録(初回のみ)', class: 'container btn btn-secondary my-1' %>
@@ -37,6 +38,7 @@
         <%= f.hidden_field :username, value: "ゲスト乙" %>
         <%= f.hidden_field :email, value: "guest2@mail.com" %>
         <%= f.hidden_field :profile, value: "このアカウントはポートフォリオの内容を確認するためのものです。" %>
+        <%= f.hidden_field :guest_flg, value: "true" %>
         <%= f.hidden_field :password, value: "guestguest2" %>
       </div>
       <%= f.submit 'ゲスト乙として登録(初回のみ)', class: 'container btn btn-secondary my-1' %>
@@ -60,6 +62,7 @@
         <%= f.hidden_field :username, value: "ゲスト丙" %>
         <%= f.hidden_field :email, value: "guest3@mail.com" %>
         <%= f.hidden_field :profile, value: "このアカウントはポートフォリオの内容を確認するためのものです。" %>
+        <%= f.hidden_field :guest_flg, value: "true" %>
         <%= f.hidden_field :password, value: "guestguest3" %>
       </div>
       <%= f.submit 'ゲスト丙として登録(初回のみ)', class: 'container btn btn-secondary my-1' %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -37,12 +37,18 @@
           <%= f.password_field :current_password, autocomplete: "current_password",
               class: "form-control", placeholder: "現在のパスワード" %>
         </div>
-        <div class="actions">
-          <%= f.submit "アカウント情報を更新する", class: "btn btn-sm btn-success" %>
-        </div>
-        <div>
-          <%= link_to "アカウントの削除", registration_path(resource_name), data: { confirm: "本当に削除しますか？" }, method: :delete, class: 'btn btn-sm btn-danger', id: 'delete-btn' %>
-        </div>
+        <% if current_user.guest_flg == true %>
+          <div class="btn btn-sm btn-success">
+            ゲスト用のアカウントでは登録情報の操作はできません
+          </div>
+        <% else %>
+          <div class="actions">
+            <%= f.submit "アカウント情報を更新する", class: "btn btn-sm btn-success" %>
+          </div>
+          <div>
+            <%= link_to "アカウントの削除", registration_path(resource_name), data: { confirm: "本当に削除しますか？" }, method: :delete, class: 'btn btn-sm btn-danger', id: 'delete-btn' %>
+          </div>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -20,7 +20,7 @@
             id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= image_tag current_user.image.url, class: 'rounded', :size => '15x15' if current_user.image.url.present? %>
             <%= current_user.username %> さん
-            <%= render 'users/user_card_admin_badge', user: current_user %>
+            <%= render 'users/user_card_attribute_badge', user: current_user %>
           </button>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
             <button class="dropdown-item" type="button"><%= link_to 'ログアウト', destroy_user_session_path, method: :delete %></button>

--- a/app/views/users/_user_card.html.erb
+++ b/app/views/users/_user_card.html.erb
@@ -8,7 +8,7 @@
         <div class="flex-column">
           <div class="font-weight-bold" id="name">
             <%= link_to user.username, user, id: "user-more" %>
-            <%= render 'users/user_card_admin_badge', user: user %>
+            <%= render 'users/user_card_attribute_badge', user: user %>
           </div>
           <div class="d-flex">
             <div class="d-flex flex-column" id="name">

--- a/app/views/users/_user_card_attribute_badge.html.erb
+++ b/app/views/users/_user_card_attribute_badge.html.erb
@@ -1,3 +1,5 @@
 <% if user.admin_flg == true %>
   <div class="ml-1 badge badge-sm badge-danger">管理者</div>
+<% if user.guest_flg == true %>
+  <div class="ml-1 badge badge-sm badge-danger">ゲスト</div>
 <% end %>

--- a/app/views/users/_user_card_attribute_badge.html.erb
+++ b/app/views/users/_user_card_attribute_badge.html.erb
@@ -1,5 +1,5 @@
 <% if user.admin_flg == true %>
   <div class="ml-1 badge badge-sm badge-danger">管理者</div>
-<% if user.guest_flg == true %>
-  <div class="ml-1 badge badge-sm badge-danger">ゲスト</div>
+<% elsif user.guest_flg == true %>
+  <div class="ml-1 badge badge-sm badge-warning">閲覧用ゲスト</div>
 <% end %>

--- a/db/migrate/20190827082609_add_guest_flg_to_user.rb
+++ b/db/migrate/20190827082609_add_guest_flg_to_user.rb
@@ -1,0 +1,5 @@
+class AddGuestFlgToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :guest_flg, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_26_130213) do
+ActiveRecord::Schema.define(version: 2019_08_27_082609) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -121,6 +121,7 @@ ActiveRecord::Schema.define(version: 2019_08_26_130213) do
     t.integer "stock_count", default: 0
     t.integer "article_count", default: 0
     t.integer "comment_count", default: 0
+    t.boolean "guest_flg"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end


### PR DESCRIPTION
- Userテーブルにguest_flg:booleanを追加, trueであれば以下

  - User/editは閲覧できるが、送信ボタンを無効なものに変更(※画像は下記の識別バッジ追加前)
     <img width="1432" alt="スクリーンショット 2019-08-27 18 28 40" src="https://user-images.githubusercontent.com/43542677/63762280-83801080-c8fd-11e9-884b-9e8e649b9e13.png">


  - アカウント名の後にadmin同様に識別バッジを表示する
     <img width="1440" alt="スクリーンショット 2019-08-27 18 51 42" src="https://user-images.githubusercontent.com/43542677/63762416-b2968200-c8fd-11e9-9e05-b399b001758e.png">

その他、初回のゲスト生成時にguest_flg == trueとして登録するように変更。