### PR TITLE
[ 機能追加 ] 記事属性バッジの追加 & アプデお知らせ記事の区別

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -50,6 +50,6 @@ class ArticlesController < ApplicationController
   private
 
    def article_params
-     params.require(:article).permit(:title, :body, :tag_list, :article_picture)
+     params.require(:article).permit(:title, :body, :tag_list, :article_picture, :update_note)
    end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -20,4 +20,5 @@ class Article < ApplicationRecord
   scope :sidebar_limit, -> { limit(10) }
   scope :by_dates, -> { order(created_at: :desc) }
   scope :by_comments, -> { order(comment_count: :desc) }
+  scope :update_notice, -> { where(update_note: true) }
 end

--- a/app/views/articles/_article_card.html.erb
+++ b/app/views/articles/_article_card.html.erb
@@ -16,6 +16,7 @@
     <% end %>
   </div>
   <div class="card-header border-secondary rounded-0 p-1 pl-2" id="title">
+    <%= render 'articles/article_card_notice_type_badge', article: article %>
     <%= article.title %>
   </div>
   <div class="card-header d-flex justify-content-between">

--- a/app/views/articles/_article_card_notice_type_badge.html.erb
+++ b/app/views/articles/_article_card_notice_type_badge.html.erb
@@ -1,0 +1,3 @@
+<% if article.update_note == true %>
+  <div class="ml-r rounded-pill badge badge-sm badge-warning">アプリ更新</div>
+<% end %>

--- a/app/views/articles/_articles_cards_card.html.erb
+++ b/app/views/articles/_articles_cards_card.html.erb
@@ -18,7 +18,10 @@
   <%= render 'articles/articles_cards_card_modal_user', article: article, user: article.user, user_type: user_type %>
   <button type="button" data-toggle="modal" data-target="#article-modal-<%= article_type %>-<%= article.id %>" class="m-0 p-0 border-0" id="modal-btn">
     <div class="card-header rounded-0 p-1 px-2 btn-secondary text-align-start" data-toggle="modal" data-target="#article-modal">
-      <div class="align-self-center text-truncate text-left" id="title"><%= article.title %></div>
+      <div class="align-self-center text-truncate text-left" id="title">
+        <%= render 'articles/article_card_notice_type_badge', article: article %>
+        <%= article.title %>
+      </div>
     </div>
     <div class="card d-flex m-0 p-0 justify-content-center">
       <div class="articles-cards-picture-field">

--- a/app/views/articles/_articles_cards_card_modal_article.html.erb
+++ b/app/views/articles/_articles_cards_card_modal_article.html.erb
@@ -23,7 +23,10 @@
       <% end %>
       <%= link_to article do %>
         <div class="modal-header border-secondary rounded-0 p-1 pl-2" id="title">
-          <%= article.title %>
+          <div class="">
+            <%= render 'articles/article_card_notice_type_badge', article: article %>
+            <%= article.title %>
+          </div>
         </div>
       <% end %>
       <div class="modal-header rounded-0 p-1 pl-2">

--- a/app/views/articles/_new_or_edit_form_for_article.html.erb
+++ b/app/views/articles/_new_or_edit_form_for_article.html.erb
@@ -41,6 +41,9 @@
       <span :tag_list, class="input-group-text px-4">タグ</span>
       <%= f.text_field :tag_list, value: @article.tag_list.join(","), class: 'form-control', placeholder: "タグを追加(複数可)" %>
     </div>
+    <% if current_user.admin_flg == true %>
+      <div class="badge badge-lg badge-danger mb-2"><%= f.check_box :update_note, value: 'true' %>アップデートのお知らせ</div>
+    <% end %>
     <div class="mb-3">
       <% if current_page?(new_article_path) %>
         <%= f.submit '上記の内容で投稿する', class: 'btn btn-secondary btn-lg btn-block' %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -13,7 +13,7 @@
                 --<%= article.created_at.strftime("%m/%d") %>
               </div>
             </div>
-        <% end %>
+          <% end %>
         <% end %>
       </div>
   </div>
@@ -31,7 +31,25 @@
                 --(<%= article.comment_count %>)
               </div>
             </div>
+          <% end %>
         <% end %>
+      </div>
+  </div>
+  <% @articles = Article.update_notice.by_dates.sidebar_limit %>
+  <div class="card rounded-0 mb-4" id="sidebar-card">
+    <div class="card-header rounded-0 p-1">最新アップデート</div>
+      <div class="card-body p-1">
+        <% @articles.each do |article| %>
+          <%= link_to article do %>
+            <div class="row d-flex mx-auto justify-content-between">
+              <div class="px-0 col-6 col-lg-7 col-xl-8 d-flex ">
+                <div class="text-truncate"><%= article.title %></div>
+              </div>
+              <div class="d-flex">
+                --<%= article.created_at.strftime("%m/%d") %>
+              </div>
+            </div>
+          <% end %>
         <% end %>
       </div>
   </div>

--- a/app/views/users/_user_card_attribute_badge.html.erb
+++ b/app/views/users/_user_card_attribute_badge.html.erb
@@ -1,5 +1,5 @@
 <% if user.admin_flg == true %>
   <div class="ml-1 badge badge-sm badge-danger">管理者</div>
 <% elsif user.guest_flg == true %>
-  <div class="ml-1 badge badge-sm badge-warning">閲覧用ゲスト</div>
+  <div class="ml-1 badge badge-sm badge-primary">閲覧用ゲスト</div>
 <% end %>

--- a/db/migrate/20190505053918_add_admin_flg_to_user.rb
+++ b/db/migrate/20190505053918_add_admin_flg_to_user.rb
@@ -1,5 +1,5 @@
 class AddAdminFlgToUser < ActiveRecord::Migration[5.2]
   def change
-    add_column :users, :admin_flg, :boolean
+    add_column :users, :admin_flg, :boolean, default: 0
   end
 end

--- a/db/migrate/20190827082609_add_guest_flg_to_user.rb
+++ b/db/migrate/20190827082609_add_guest_flg_to_user.rb
@@ -1,5 +1,5 @@
 class AddGuestFlgToUser < ActiveRecord::Migration[5.2]
   def change
-    add_column :users, :guest_flg, :boolean
+    add_column :users, :guest_flg, :boolean, default: 0
   end
 end

--- a/db/migrate/20190829034310_add_update_flg_to_article.rb
+++ b/db/migrate/20190829034310_add_update_flg_to_article.rb
@@ -1,0 +1,5 @@
+class AddUpdateFlgToArticle < ActiveRecord::Migration[5.2]
+  def change
+    add_column :articles, :update_note, :boolean
+  end
+end

--- a/db/migrate/20190829034310_add_update_flg_to_article.rb
+++ b/db/migrate/20190829034310_add_update_flg_to_article.rb
@@ -1,5 +1,5 @@
 class AddUpdateFlgToArticle < ActiveRecord::Migration[5.2]
   def change
-    add_column :articles, :update_note, :boolean
+    add_column :articles, :update_note, :boolean, default: 0
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_27_082609) do
+ActiveRecord::Schema.define(version: 2019_08_29_034310) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2019_08_27_082609) do
     t.integer "comment_count", default: 0
     t.integer "stock_count", default: 0
     t.string "article_picture"
+    t.boolean "update_note"
   end
 
   create_table "comments", force: :cascade do |t|


### PR DESCRIPTION
### 更新動機
- アプリの機能更新をお知らせする内容の記事は他の記事と区別したかった。
- サイドバーでお知らせ記事だけをチェックできればよい。

### 更新概要

1. Articleテーブルにお知らせ記事の属性を示すupdate_note:booleanカラムを追加。
2. 記事投稿＆編集において管理者のみ値をtrueに出来る専用チェックボックスを追加。
3. 記事属性を示すバッジを記事タイトルの直前に表示(今回は'アプデお知らせ'のみ実装)
4. アップデートお知らせ記事はサイドバーで新たにボックスを設けて投稿順に一覧表示される。

**管理者アカウントの場合の記事投稿or編集画面**
  <img width="1419" alt="スクリーンショット 2019-08-29 13 52 38" src="https://user-images.githubusercontent.com/43542677/63911569-b34a2800-ca65-11e9-85cb-38e138afd7c6.png">

**記事投稿or更新後の表示(記事タイトルの前に属性バッジ、アプデお知らせサイドバーへの表示)**
<img width="1420" alt="スクリーンショット 2019-08-29 13 53 03" src="https://user-images.githubusercontent.com/43542677/63911850-bd205b00-ca66-11e9-9ccd-fe34ff4d3806.png">
<img width="1416" alt="スクリーンショット 2019-08-29 13 53 31" src="https://user-images.githubusercontent.com/43542677/63911917-f48f0780-ca66-11e9-9f7f-69162742b010.png">

